### PR TITLE
Fix typo in pubsec.yaml causing build to fail

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,8 +31,8 @@ flutter:
   plugin:
     platforms:
       web:
-        pluginClass: GRecaptchV3Web
-        fileName: g_recaptch_v3_web.dart
+        pluginClass: GRecaptchaV3Web
+        fileName: g_recaptcha_v3_web.dart
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
This is causing generated_plugin_registrant to be corrupt and causing the build to fail.